### PR TITLE
build: alinha Vite target e rebuildConfig com Electron 37

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -25,7 +25,9 @@ const config: ForgeConfig = {
       './assets/icon-256.png'
     ]
   },
-  rebuildConfig: {},
+  rebuildConfig: {
+    onlyModules: ['sqlite3'],
+  },
   makers: [
     new MakerSquirrel({
       name: 'biblia-sagrada',

--- a/vite.main.config.ts
+++ b/vite.main.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vite';
 // https://vitejs.dev/config
 export default defineConfig({
   build: {
-    target: 'node14',
+    target: 'es2022',
     rollupOptions: {
       external: [
         'sqlite3',

--- a/vite.preload.config.ts
+++ b/vite.preload.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vite';
 // https://vitejs.dev/config
 export default defineConfig({
   build: {
-    target: 'node14',
+    target: 'es2022',
     rollupOptions: {
       external: [
         'sqlite3',


### PR DESCRIPTION
Closes #7

## Mudanças
- `vite.main.config.ts:6` e `vite.preload.config.ts:6`: `target: 'node14'` → `'es2022'` (Electron 37 usa Node 22/Chromium 138).
- `forge.config.ts:28`: `rebuildConfig: {}` → `{ onlyModules: ['sqlite3'] }` para evitar recompilar deps JS puras.
- Mantém `packagerConfig.icon` e `extraResource` já corrigidos na base (`dev`), sem reintroduzir `ignore` custom que gerava warning do VitePlugin.

## Como testar
`bun run make:deb` deve rodar sem warning de `packagerConfig.ignore` e com rebuild apenas de `sqlite3`.