### PR TITLE
perf: desabilita sourcemap em produção para reduzir pacote

### DIFF
--- a/vite.renderer.config.ts
+++ b/vite.renderer.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     emptyOutDir: true,
-    sourcemap: true,
+    sourcemap: process.env.NODE_ENV !== 'production',
   },
   server: {
     port: 5180,


### PR DESCRIPTION
Relacionado a #4

## Mudanças
- `vite.renderer.config.ts:11`: `sourcemap: true` → `process.env.NODE_ENV !== 'production'` — evita shippar maps no `.deb` (economia estimada 15-20 MB).
- `extraResource` já corrigido na base (`dev`) para apenas ícones, eliminando duplicação de `KJA.json` (4.4 MB).
- Locales do Electron (~30 MB) ficam como follow-up via hook `afterCopy` para manter só `pt-BR`/`en` (documentado em #4).

## Meta
`.deb` 93 MB → <75 MB nesta etapa, <55 MB após locales + DB pré-populado.