### PR TITLE
perf: code splitting e lazy loading das rotas

### DIFF
--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -3,12 +3,12 @@ import { createRoot } from 'react-dom/client';
 import Layout from './components/Layout';
 import Inicio from './pages/Inicio';
 import Biblia from './pages/Biblia';
-import Busca from './pages/Busca';
 import { TemaProvider } from './hooks/useTema';
 import { NavegacaoProvider } from './hooks/useNavegacao';
 import './index.css';
 
-// Lazy loading das páginas para melhor performance
+// Lazy loading para reduzir bundle inicial (issue #5)
+const Busca = React.lazy(() => import('./pages/Busca'));
 const Favoritos = React.lazy(() => import('./pages/Favoritos'));
 const Anotacoes = React.lazy(() => import('./pages/Anotacoes'));
 const Configuracoes = React.lazy(() => import('./pages/Configuracoes'));
@@ -81,7 +81,11 @@ const App: React.FC = () => {
       case 'biblia':
         return <Biblia />;
       case 'busca':
-        return <Busca />;
+        return (
+          <React.Suspense fallback={<div className="p-6">Carregando busca...</div>}>
+            <Busca />
+          </React.Suspense>
+        );
       case 'favoritos':
         return (
           <React.Suspense fallback={<div className="p-6">Carregando favoritos...</div>}>

--- a/vite.renderer.config.ts
+++ b/vite.renderer.config.ts
@@ -8,7 +8,15 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     emptyOutDir: true,
-    sourcemap: true,
+    sourcemap: process.env.NODE_ENV !== 'production',
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          radix: ['@radix-ui/react-dialog', '@radix-ui/react-dropdown-menu', '@radix-ui/react-select', '@radix-ui/react-slot', '@radix-ui/react-switch', '@radix-ui/react-tabs'],
+          lucide: ['lucide-react'],
+        },
+      },
+    },
   },
   server: {
     port: 5180,


### PR DESCRIPTION
Closes #5

## Mudanças
- `src/renderer.tsx`: `Busca` passa a `React.lazy` com `Suspense` (antes eager), completando splitting de todas as rotas secundárias.
- `vite.renderer.config.ts`: `manualChunks` para `radix` (`@radix-ui/*`) e `lucide` (`lucide-react`) + `sourcemap` condicional em produção.

## Como testar
`bun run dev` e navegar entre Início/Bíblia/Busca/Favoritos — chunks carregados sob demanda sem flash, verificar no DevTools Network.